### PR TITLE
Propagate request for websocket handling

### DIFF
--- a/source/examples/websockets/Server.cpp
+++ b/source/examples/websockets/Server.cpp
@@ -97,7 +97,7 @@ void Server::handleBinary(tastefulserver::WebSocket * socket, const QByteArray &
     socket->sendBinary(binary);
 }
 
-void Server::connectionEstablished(tastefulserver::WebSocket * socket)
+void Server::connectionEstablished(const tastefulserver::HttpRequest & /*request*/, tastefulserver::WebSocket * socket)
 {
     QTimer * timer = new QTimer(socket);
     timer->setInterval(1000);

--- a/source/examples/websockets/Server.h
+++ b/source/examples/websockets/Server.h
@@ -13,5 +13,5 @@ protected:
 
     virtual void handleText(tastefulserver::WebSocket * socket, const QByteArray & text) override;
     virtual void handleBinary(tastefulserver::WebSocket * socket, const QByteArray & binary) override;
-    virtual void connectionEstablished(tastefulserver::WebSocket * socket) override;
+    virtual void connectionEstablished(const tastefulserver::HttpRequest & request, tastefulserver::WebSocket * socket) override;
 };

--- a/source/tastefulserver/include/tastefulserver/HttpWebSocketServer.h
+++ b/source/tastefulserver/include/tastefulserver/HttpWebSocketServer.h
@@ -24,7 +24,7 @@ protected:
 
     //virtual void handleText(WebSocket * socket, const QByteArray & text) override;
     //virtual void handleBinary(WebSocket * socket, const QByteArray & binary) override;
-    //virtual void connectionEstablished(WebSocket * socket) override;
+    //virtual void connectionEstablished(WebSocket * socket, const HttpRequest & request) override;
 };
 
 } // namespace tastefulserver

--- a/source/tastefulserver/include/tastefulserver/WebSocketHandler.h
+++ b/source/tastefulserver/include/tastefulserver/WebSocketHandler.h
@@ -9,7 +9,7 @@ namespace tastefulserver {
 class TASTEFULSERVER_API WebSocketHandler
 {
 public:
-    virtual void connectionEstablished(WebSocket * socket);
+    virtual void connectionEstablished(const HttpRequest & request, WebSocket * socket);
     virtual void connectionClosed(WebSocket * socket);
 
     virtual void handleText(WebSocket * socket, const QByteArray & text) = 0;

--- a/source/tastefulserver/include/tastefulserver/WebSocketServer.h
+++ b/source/tastefulserver/include/tastefulserver/WebSocketServer.h
@@ -23,7 +23,7 @@ protected:
 
     //virtual void handleText(WebSocket * socket, const QByteArray & text) override;
     //virtual void handleBinary(WebSocket * socket, const QByteArray & binary) override;
-    //virtual void connectionEstablished(WebSocket * socket) override;
+    //virtual void connectionEstablished(const HttpRequest & request, WebSocket * socket) override;
     //virtual void connectionClosed(WebSocket * socket) override;
 };
 

--- a/source/tastefulserver/source/websocket/WebSocket.cpp
+++ b/source/tastefulserver/source/websocket/WebSocket.cpp
@@ -49,7 +49,7 @@ void WebSocket::performHandshake(const HttpRequest & request)
 
     response.writeTo(*m_socket);
 
-    m_handler->connectionEstablished(this);
+    m_handler->connectionEstablished(request, this);
 
     connect(m_socket, SIGNAL(disconnected()), this, SLOT(connectionClosed()));
 }

--- a/source/tastefulserver/source/websocket/WebSocketHandler.cpp
+++ b/source/tastefulserver/source/websocket/WebSocketHandler.cpp
@@ -2,7 +2,7 @@
 
 namespace tastefulserver {
 
-void WebSocketHandler::connectionEstablished(WebSocket * )
+void WebSocketHandler::connectionEstablished(const HttpRequest & /*request*/, WebSocket * /*socket*/)
 {
 }
 


### PR DESCRIPTION
Adds the request to connectionEstablished. This allows to handle an incoming websocket depending on the route and added parameter of the request.